### PR TITLE
Add admin UI for chord submission review and approval

### DIFF
--- a/src/ClientApp/src/script/models/account.ts
+++ b/src/ClientApp/src/script/models/account.ts
@@ -14,6 +14,7 @@ export interface UserViewModel {
     lastName?: string;
     registrationDate?: string;
     profilePictureUrl?: string | null;
+    isAdmin: boolean;
     starredChartIds: string[];
     starredChordCharts: Record<string, string>;
     editedChordCharts: Record<string, string>;

--- a/src/ClientApp/src/script/models/chord-submission.ts
+++ b/src/ClientApp/src/script/models/chord-submission.ts
@@ -10,3 +10,8 @@ export interface ChordSubmissionAttachment {
     untrustedFileName: string;
     cdnUri: string;
 }
+
+export interface PendingChordSubmission {
+    submission: ChordSubmission;
+    original: ChordSheet | null;
+}

--- a/src/ClientApp/src/script/models/chord-submission.ts
+++ b/src/ClientApp/src/script/models/chord-submission.ts
@@ -1,0 +1,12 @@
+import { ChordSheet } from "./interfaces";
+
+export interface ChordSubmission extends ChordSheet {
+    editedChordSheetId: string | null;
+    savedAttachments: ChordSubmissionAttachment[];
+}
+
+export interface ChordSubmissionAttachment {
+    cdnFileName: string;
+    untrustedFileName: string;
+    cdnUri: string;
+}

--- a/src/ClientApp/src/script/pages/admin-submissions.styles.ts
+++ b/src/ClientApp/src/script/pages/admin-submissions.styles.ts
@@ -43,10 +43,11 @@ export const adminSubmissionsStyles = css`
     .submission-badge {
         display: inline-block;
         font-size: 0.75rem;
-        padding: 2px 8px;
+        padding: 4px 10px;
         border-radius: 12px;
         font-weight: 600;
         text-transform: uppercase;
+        white-space: nowrap;
     }
 
     .badge-new {
@@ -57,6 +58,16 @@ export const adminSubmissionsStyles = css`
     .badge-edit {
         background: #e8e6f0;
         color: #35338c;
+    }
+
+    .editing-info {
+        font-size: 0.9rem;
+        color: #555;
+        margin: 0 0 12px 0;
+    }
+
+    .editing-info a {
+        color: var(--sl-color-primary-700, #6665a8);
     }
 
     .submission-details {
@@ -82,17 +93,123 @@ export const adminSubmissionsStyles = css`
         font-size: 0.95rem;
     }
 
+    /* Diff table styles */
+    .diff-section-title {
+        font-size: 0.95rem;
+        font-weight: 600;
+        margin: 16px 0 8px 0;
+        color: #333;
+    }
+
+    .diff-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 16px;
+        font-size: 0.9rem;
+    }
+
+    .diff-table th {
+        text-align: left;
+        padding: 8px 12px;
+        background: #eee;
+        border-bottom: 2px solid #ddd;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #555;
+    }
+
+    .diff-table td {
+        padding: 8px 12px;
+        border-bottom: 1px solid #e8e8e8;
+        vertical-align: top;
+    }
+
+    .diff-field-name {
+        font-weight: 600;
+        white-space: nowrap;
+        width: 120px;
+    }
+
+    .diff-new {
+        background: #e6ffec;
+    }
+
+    .diff-old {
+        background: #fff1e5;
+        color: #7a5a3a;
+    }
+
+    .empty-val {
+        color: #aaa;
+        font-style: italic;
+    }
+
+    .chords-diff {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+        margin-bottom: 16px;
+    }
+
+    .chords-diff-panel {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .chords-diff-label {
+        font-size: 0.8rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #555;
+        margin-bottom: 4px;
+    }
+
     .chords-preview {
         max-height: 200px;
         overflow-y: auto;
-        background: white;
-        border: 1px solid #ddd;
+        background: #e6ffec;
+        border: 1px solid #b7d9b7;
         border-radius: 4px;
         padding: 12px;
         font-family: monospace;
         font-size: 0.85rem;
         white-space: pre-wrap;
+        flex: 1;
+    }
+
+    .chords-old {
+        background: #fff1e5;
+        border-color: #e0c9a8;
+    }
+
+    .links-diff {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
         margin-bottom: 16px;
+    }
+
+    .no-changes {
+        color: #888;
+        font-style: italic;
+        margin: 8px 0 16px 0;
+    }
+
+    .unchanged-details {
+        margin-bottom: 16px;
+    }
+
+    .unchanged-details summary {
+        cursor: pointer;
+        color: #888;
+        font-size: 0.85rem;
+        margin-bottom: 8px;
+    }
+
+    .unchanged-details summary:hover {
+        color: #555;
     }
 
     .attachments-list {
@@ -134,5 +251,12 @@ export const adminSubmissionsStyles = css`
     .submitted-date {
         font-size: 0.85rem;
         color: #888;
+    }
+
+    @media (max-width: 600px) {
+        .chords-diff,
+        .links-diff {
+            grid-template-columns: 1fr;
+        }
     }
 `;

--- a/src/ClientApp/src/script/pages/admin-submissions.styles.ts
+++ b/src/ClientApp/src/script/pages/admin-submissions.styles.ts
@@ -1,0 +1,138 @@
+import { css } from "lit";
+
+export const adminSubmissionsStyles = css`
+    :host {
+        display: block;
+        padding: 20px;
+    }
+
+    .admin-page {
+        max-width: 1200px;
+        margin: 0 auto;
+    }
+
+    .submission-card {
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+        padding: 20px;
+        margin-bottom: 16px;
+        background: #fafafa;
+    }
+
+    .submission-card.is-edit {
+        border-left: 4px solid var(--sl-color-primary-600, #7f80b6);
+    }
+
+    .submission-card.is-new {
+        border-left: 4px solid #28a745;
+    }
+
+    .submission-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: 12px;
+    }
+
+    .submission-title {
+        font-size: 1.2rem;
+        font-weight: 600;
+        margin: 0;
+    }
+
+    .submission-badge {
+        display: inline-block;
+        font-size: 0.75rem;
+        padding: 2px 8px;
+        border-radius: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+    }
+
+    .badge-new {
+        background: #d4edda;
+        color: #155724;
+    }
+
+    .badge-edit {
+        background: #e8e6f0;
+        color: #35338c;
+    }
+
+    .submission-details {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+        gap: 8px 24px;
+        margin-bottom: 16px;
+    }
+
+    .detail-item {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .detail-label {
+        font-size: 0.8rem;
+        color: #666;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .detail-value {
+        font-size: 0.95rem;
+    }
+
+    .chords-preview {
+        max-height: 200px;
+        overflow-y: auto;
+        background: white;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        padding: 12px;
+        font-family: monospace;
+        font-size: 0.85rem;
+        white-space: pre-wrap;
+        margin-bottom: 16px;
+    }
+
+    .attachments-list {
+        list-style: none;
+        padding: 0;
+        margin: 0 0 16px 0;
+    }
+
+    .attachments-list li {
+        margin-bottom: 4px;
+    }
+
+    .attachments-list a {
+        color: var(--sl-color-primary-700, #6665a8);
+    }
+
+    .submission-actions {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+    }
+
+    .empty-state {
+        text-align: center;
+        padding: 40px;
+        color: #666;
+    }
+
+    .empty-state sl-icon {
+        font-size: 3rem;
+        margin-bottom: 16px;
+        display: block;
+    }
+
+    .error-alert {
+        margin-bottom: 16px;
+    }
+
+    .submitted-date {
+        font-size: 0.85rem;
+        color: #888;
+    }
+`;

--- a/src/ClientApp/src/script/pages/admin-submissions.ts
+++ b/src/ClientApp/src/script/pages/admin-submissions.ts
@@ -1,0 +1,244 @@
+import { html, LitElement, TemplateResult, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { sharedStyles } from "../common/shared.styles";
+import { adminSubmissionsStyles } from "./admin-submissions.styles";
+import { ChordSubmission } from "../models/chord-submission";
+import { adminService } from "../services/admin-service";
+import { accountService } from "../services/account-service";
+
+import "@shoelace-style/shoelace/dist/components/alert/alert.js";
+import "@shoelace-style/shoelace/dist/components/button/button.js";
+import "@shoelace-style/shoelace/dist/components/spinner/spinner.js";
+
+@customElement("admin-submissions")
+export class AdminSubmissions extends LitElement {
+    static styles = [sharedStyles, adminSubmissionsStyles];
+
+    @state() submissions: ChordSubmission[] = [];
+    @state() isLoading = true;
+    @state() error: string | null = null;
+    @state() processingIds: Set<string> = new Set();
+    @state() isAdmin = false;
+
+    connectedCallback(): void {
+        super.connectedCallback();
+        this.checkAdminAndLoad();
+    }
+
+    private async checkAdminAndLoad(): Promise<void> {
+        try {
+            const user = await accountService.getUser();
+            if (!user?.isAdmin) {
+                this.isAdmin = false;
+                this.isLoading = false;
+                return;
+            }
+            this.isAdmin = true;
+            await this.loadSubmissions();
+        } catch {
+            this.error = "Failed to verify admin access.";
+            this.isLoading = false;
+        }
+    }
+
+    private async loadSubmissions(): Promise<void> {
+        this.isLoading = true;
+        this.error = null;
+        try {
+            this.submissions = await adminService.getPendingSubmissions();
+        } catch {
+            this.error = "Failed to load submissions.";
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    render(): TemplateResult {
+        return html`
+            <div class="admin-page">
+                <h2 class="highlight">Pending Submissions</h2>
+
+                ${this.error ? html`
+                    <sl-alert variant="danger" open class="error-alert">
+                        ${this.error}
+                    </sl-alert>
+                ` : nothing}
+
+                ${this.renderContent()}
+            </div>
+        `;
+    }
+
+    private renderContent(): TemplateResult | typeof nothing {
+        if (!this.isAdmin && !this.isLoading) {
+            return html`
+                <div class="empty-state">
+                    <p>You must be signed in as an admin to access this page.</p>
+                    <sl-button variant="primary" href="/account">Sign In</sl-button>
+                </div>
+            `;
+        }
+
+        if (this.isLoading) {
+            return html`
+                <div class="empty-state">
+                    <sl-spinner style="font-size: 2rem;"></sl-spinner>
+                    <p>Loading submissions...</p>
+                </div>
+            `;
+        }
+
+        if (this.submissions.length === 0) {
+            return html`
+                <div class="empty-state">
+                    <p>🎉 No pending submissions. All caught up!</p>
+                </div>
+            `;
+        }
+
+        return html`
+            <p>${this.submissions.length} pending submission${this.submissions.length === 1 ? "" : "s"}</p>
+            ${this.submissions.map(s => this.renderSubmission(s))}
+        `;
+    }
+
+    private renderSubmission(submission: ChordSubmission): TemplateResult {
+        const isNew = !submission.editedChordSheetId;
+        const isProcessing = this.processingIds.has(submission.id);
+
+        return html`
+            <div class="submission-card ${isNew ? "is-new" : "is-edit"}">
+                <div class="submission-header">
+                    <div>
+                        <h3 class="submission-title">${submission.artist} - ${submission.song}${submission.hebrewSongName ? ` ${submission.hebrewSongName}` : ""}</h3>
+                        <span class="submitted-date">Submitted ${this.formatDate(submission.created)}</span>
+                    </div>
+                    <span class="submission-badge ${isNew ? "badge-new" : "badge-edit"}">
+                        ${isNew ? "New" : "Edit"}
+                    </span>
+                </div>
+
+                <div class="submission-details">
+                    ${submission.key ? html`
+                        <div class="detail-item">
+                            <span class="detail-label">Key</span>
+                            <span class="detail-value">${submission.key}</span>
+                        </div>
+                    ` : nothing}
+                    ${submission.capo ? html`
+                        <div class="detail-item">
+                            <span class="detail-label">Capo</span>
+                            <span class="detail-value">${submission.capo}</span>
+                        </div>
+                    ` : nothing}
+                    ${submission.authors.length > 0 ? html`
+                        <div class="detail-item">
+                            <span class="detail-label">Authors</span>
+                            <span class="detail-value">${submission.authors.join(", ")}</span>
+                        </div>
+                    ` : nothing}
+                    ${submission.copyright ? html`
+                        <div class="detail-item">
+                            <span class="detail-label">Copyright</span>
+                            <span class="detail-value">${submission.copyright}</span>
+                        </div>
+                    ` : nothing}
+                    ${submission.scripture ? html`
+                        <div class="detail-item">
+                            <span class="detail-label">Scripture</span>
+                            <span class="detail-value">${submission.scripture}</span>
+                        </div>
+                    ` : nothing}
+                    ${submission.year ? html`
+                        <div class="detail-item">
+                            <span class="detail-label">Year</span>
+                            <span class="detail-value">${submission.year}</span>
+                        </div>
+                    ` : nothing}
+                    ${submission.isSheetMusic ? html`
+                        <div class="detail-item">
+                            <span class="detail-label">Sheet Music</span>
+                            <span class="detail-value">Yes</span>
+                        </div>
+                    ` : nothing}
+                    ${!isNew ? html`
+                        <div class="detail-item">
+                            <span class="detail-label">Editing</span>
+                            <span class="detail-value">
+                                <a href="/chordsheets/${encodeURIComponent(submission.editedChordSheetId!.replace(/^ChordSheets\//i, ""))}">${submission.editedChordSheetId}</a>
+                            </span>
+                        </div>
+                    ` : nothing}
+                </div>
+
+                ${submission.chords ? html`
+                    <div class="chords-preview">${submission.chords}</div>
+                ` : nothing}
+
+                ${submission.savedAttachments.length > 0 ? html`
+                    <ul class="attachments-list">
+                        ${submission.savedAttachments.map(a => html`
+                            <li>📎 <a href="${a.cdnUri}" target="_blank">${a.untrustedFileName}</a></li>
+                        `)}
+                    </ul>
+                ` : nothing}
+
+                ${submission.links.length > 0 ? html`
+                    <div class="detail-item" style="margin-bottom: 16px;">
+                        <span class="detail-label">Links</span>
+                        ${submission.links.map(link => html`<a href="${link}" target="_blank" style="display:block; font-size: 0.9rem;">${link}</a>`)}
+                    </div>
+                ` : nothing}
+
+                <div class="submission-actions">
+                    <sl-button
+                        variant="success"
+                        ?loading="${isProcessing}"
+                        ?disabled="${isProcessing}"
+                        @click="${() => this.approve(submission)}">
+                        ✅ Approve
+                    </sl-button>
+                    <sl-button
+                        variant="danger"
+                        ?loading="${isProcessing}"
+                        ?disabled="${isProcessing}"
+                        @click="${() => this.reject(submission)}">
+                        ❌ Reject
+                    </sl-button>
+                </div>
+            </div>
+        `;
+    }
+
+    private async approve(submission: ChordSubmission): Promise<void> {
+        if (!submission.id) return;
+        await this.processSubmission(submission.id, () => adminService.approveSubmission(submission.id));
+    }
+
+    private async reject(submission: ChordSubmission): Promise<void> {
+        if (!submission.id) return;
+        await this.processSubmission(submission.id, () => adminService.rejectSubmission(submission.id));
+    }
+
+    private async processSubmission(submissionId: string, action: () => Promise<unknown>): Promise<void> {
+        this.processingIds = new Set([...this.processingIds, submissionId]);
+        this.error = null;
+        try {
+            await action();
+            this.submissions = this.submissions.filter(s => s.id !== submissionId);
+        } catch {
+            this.error = `Failed to process submission ${submissionId}.`;
+        } finally {
+            const newSet = new Set(this.processingIds);
+            newSet.delete(submissionId);
+            this.processingIds = newSet;
+        }
+    }
+
+    private formatDate(date?: string): string {
+        if (!date) return "";
+        const parsed = new Date(date);
+        if (Number.isNaN(parsed.getTime())) return "";
+        return parsed.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+    }
+}

--- a/src/ClientApp/src/script/pages/admin-submissions.ts
+++ b/src/ClientApp/src/script/pages/admin-submissions.ts
@@ -2,7 +2,8 @@ import { html, LitElement, TemplateResult, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { sharedStyles } from "../common/shared.styles";
 import { adminSubmissionsStyles } from "./admin-submissions.styles";
-import { ChordSubmission } from "../models/chord-submission";
+import { ChordSubmission, PendingChordSubmission } from "../models/chord-submission";
+import { ChordSheet } from "../models/interfaces";
 import { adminService } from "../services/admin-service";
 import { accountService } from "../services/account-service";
 
@@ -14,7 +15,7 @@ import "@shoelace-style/shoelace/dist/components/spinner/spinner.js";
 export class AdminSubmissions extends LitElement {
     static styles = [sharedStyles, adminSubmissionsStyles];
 
-    @state() submissions: ChordSubmission[] = [];
+    @state() pendingSubmissions: PendingChordSubmission[] = [];
     @state() isLoading = true;
     @state() error: string | null = null;
     @state() processingIds: Set<string> = new Set();
@@ -45,7 +46,7 @@ export class AdminSubmissions extends LitElement {
         this.isLoading = true;
         this.error = null;
         try {
-            this.submissions = await adminService.getPendingSubmissions();
+            this.pendingSubmissions = await adminService.getPendingSubmissions();
         } catch {
             this.error = "Failed to load submissions.";
         } finally {
@@ -88,7 +89,7 @@ export class AdminSubmissions extends LitElement {
             `;
         }
 
-        if (this.submissions.length === 0) {
+        if (this.pendingSubmissions.length === 0) {
             return html`
                 <div class="empty-state">
                     <p>🎉 No pending submissions. All caught up!</p>
@@ -97,12 +98,13 @@ export class AdminSubmissions extends LitElement {
         }
 
         return html`
-            <p>${this.submissions.length} pending submission${this.submissions.length === 1 ? "" : "s"}</p>
-            ${this.submissions.map(s => this.renderSubmission(s))}
+            <p>${this.pendingSubmissions.length} pending submission${this.pendingSubmissions.length === 1 ? "" : "s"}</p>
+            ${this.pendingSubmissions.map(p => this.renderSubmission(p))}
         `;
     }
 
-    private renderSubmission(submission: ChordSubmission): TemplateResult {
+    private renderSubmission(pending: PendingChordSubmission): TemplateResult {
+        const { submission, original } = pending;
         const isNew = !submission.editedChordSheetId;
         const isProcessing = this.processingIds.has(submission.id);
 
@@ -114,66 +116,19 @@ export class AdminSubmissions extends LitElement {
                         <span class="submitted-date">Submitted ${this.formatDate(submission.created)}</span>
                     </div>
                     <span class="submission-badge ${isNew ? "badge-new" : "badge-edit"}">
-                        ${isNew ? "New" : "Edit"}
+                        ${isNew ? "🆕 New Chart" : "✏️ Edit"}
                     </span>
                 </div>
 
-                <div class="submission-details">
-                    ${submission.key ? html`
-                        <div class="detail-item">
-                            <span class="detail-label">Key</span>
-                            <span class="detail-value">${submission.key}</span>
-                        </div>
-                    ` : nothing}
-                    ${submission.capo ? html`
-                        <div class="detail-item">
-                            <span class="detail-label">Capo</span>
-                            <span class="detail-value">${submission.capo}</span>
-                        </div>
-                    ` : nothing}
-                    ${submission.authors.length > 0 ? html`
-                        <div class="detail-item">
-                            <span class="detail-label">Authors</span>
-                            <span class="detail-value">${submission.authors.join(", ")}</span>
-                        </div>
-                    ` : nothing}
-                    ${submission.copyright ? html`
-                        <div class="detail-item">
-                            <span class="detail-label">Copyright</span>
-                            <span class="detail-value">${submission.copyright}</span>
-                        </div>
-                    ` : nothing}
-                    ${submission.scripture ? html`
-                        <div class="detail-item">
-                            <span class="detail-label">Scripture</span>
-                            <span class="detail-value">${submission.scripture}</span>
-                        </div>
-                    ` : nothing}
-                    ${submission.year ? html`
-                        <div class="detail-item">
-                            <span class="detail-label">Year</span>
-                            <span class="detail-value">${submission.year}</span>
-                        </div>
-                    ` : nothing}
-                    ${submission.isSheetMusic ? html`
-                        <div class="detail-item">
-                            <span class="detail-label">Sheet Music</span>
-                            <span class="detail-value">Yes</span>
-                        </div>
-                    ` : nothing}
-                    ${!isNew ? html`
-                        <div class="detail-item">
-                            <span class="detail-label">Editing</span>
-                            <span class="detail-value">
-                                <a href="/chordsheets/${encodeURIComponent(submission.editedChordSheetId!.replace(/^ChordSheets\//i, ""))}">${submission.editedChordSheetId}</a>
-                            </span>
-                        </div>
-                    ` : nothing}
-                </div>
-
-                ${submission.chords ? html`
-                    <div class="chords-preview">${submission.chords}</div>
+                ${!isNew && original ? html`
+                    <p class="editing-info">
+                        Editing <a href="/chordsheets/${encodeURIComponent(submission.editedChordSheetId!.replace(/^ChordSheets\//i, ""))}">${original.artist} - ${original.song}</a>
+                    </p>
                 ` : nothing}
+
+                ${isNew
+                    ? this.renderNewSubmissionDetails(submission)
+                    : this.renderEditDiff(submission, original)}
 
                 ${submission.savedAttachments.length > 0 ? html`
                     <ul class="attachments-list">
@@ -181,13 +136,6 @@ export class AdminSubmissions extends LitElement {
                             <li>📎 <a href="${a.cdnUri}" target="_blank">${a.untrustedFileName}</a></li>
                         `)}
                     </ul>
-                ` : nothing}
-
-                ${submission.links.length > 0 ? html`
-                    <div class="detail-item" style="margin-bottom: 16px;">
-                        <span class="detail-label">Links</span>
-                        ${submission.links.map(link => html`<a href="${link}" target="_blank" style="display:block; font-size: 0.9rem;">${link}</a>`)}
-                    </div>
                 ` : nothing}
 
                 <div class="submission-actions">
@@ -210,6 +158,136 @@ export class AdminSubmissions extends LitElement {
         `;
     }
 
+    private renderNewSubmissionDetails(submission: ChordSubmission): TemplateResult {
+        return html`
+            <div class="submission-details">
+                ${this.renderDetailIfPresent("Song", submission.song)}
+                ${this.renderDetailIfPresent("Hebrew Name", submission.hebrewSongName)}
+                ${this.renderDetailIfPresent("Artist", submission.artist)}
+                ${this.renderDetailIfPresent("Key", submission.key)}
+                ${submission.capo ? this.renderDetailIfPresent("Capo", String(submission.capo)) : nothing}
+                ${submission.authors.length > 0 ? this.renderDetailIfPresent("Authors", submission.authors.join(", ")) : nothing}
+                ${this.renderDetailIfPresent("Copyright", submission.copyright)}
+                ${this.renderDetailIfPresent("Scripture", submission.scripture)}
+                ${submission.year ? this.renderDetailIfPresent("Year", String(submission.year)) : nothing}
+                ${submission.isSheetMusic ? this.renderDetailIfPresent("Sheet Music", "Yes") : nothing}
+                ${this.renderDetailIfPresent("About", submission.about)}
+            </div>
+
+            ${submission.chords ? html`
+                <div class="chords-preview">${submission.chords}</div>
+            ` : nothing}
+
+            ${submission.links.length > 0 ? html`
+                <div class="detail-item" style="margin-bottom: 16px;">
+                    <span class="detail-label">Links</span>
+                    ${submission.links.map(link => html`<a href="${link}" target="_blank" style="display:block; font-size: 0.9rem;">${link}</a>`)}
+                </div>
+            ` : nothing}
+        `;
+    }
+
+    private renderEditDiff(submission: ChordSubmission, original: ChordSheet | null): TemplateResult {
+        if (!original) {
+            return this.renderNewSubmissionDetails(submission);
+        }
+
+        const fields: Array<{ label: string; newVal: string; oldVal: string }> = [
+            { label: "Song", newVal: submission.song ?? "", oldVal: original.song ?? "" },
+            { label: "Hebrew Name", newVal: submission.hebrewSongName ?? "", oldVal: original.hebrewSongName ?? "" },
+            { label: "Artist", newVal: submission.artist ?? "", oldVal: original.artist ?? "" },
+            { label: "Key", newVal: submission.key ?? "", oldVal: original.key ?? "" },
+            { label: "Capo", newVal: submission.capo ? String(submission.capo) : "", oldVal: original.capo ? String(original.capo) : "" },
+            { label: "Authors", newVal: (submission.authors ?? []).join(", "), oldVal: (original.authors ?? []).join(", ") },
+            { label: "Copyright", newVal: submission.copyright ?? "", oldVal: original.copyright ?? "" },
+            { label: "Scripture", newVal: submission.scripture ?? "", oldVal: original.scripture ?? "" },
+            { label: "Year", newVal: submission.year ? String(submission.year) : "", oldVal: original.year ? String(original.year) : "" },
+            { label: "Sheet Music", newVal: submission.isSheetMusic ? "Yes" : "No", oldVal: original.isSheetMusic ? "Yes" : "No" },
+            { label: "About", newVal: submission.about ?? "", oldVal: original.about ?? "" },
+        ];
+
+        const changedFields = fields.filter(f => f.newVal !== f.oldVal);
+        const unchangedFields = fields.filter(f => f.newVal !== "" && f.newVal === f.oldVal);
+
+        const chordsChanged = (submission.chords ?? "") !== (original.chords ?? "");
+        const linksChanged = JSON.stringify(submission.links ?? []) !== JSON.stringify(original.links ?? []);
+
+        return html`
+            ${changedFields.length > 0 ? html`
+                <h4 class="diff-section-title">Changed Fields</h4>
+                <table class="diff-table">
+                    <thead>
+                        <tr>
+                            <th>Field</th>
+                            <th>New Value</th>
+                            <th>Old Value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${changedFields.map(f => html`
+                            <tr class="diff-changed">
+                                <td class="diff-field-name">${f.label}</td>
+                                <td class="diff-new">${f.newVal || html`<span class="empty-val">(empty)</span>`}</td>
+                                <td class="diff-old">${f.oldVal || html`<span class="empty-val">(empty)</span>`}</td>
+                            </tr>
+                        `)}
+                    </tbody>
+                </table>
+            ` : nothing}
+
+            ${chordsChanged ? html`
+                <h4 class="diff-section-title">Chords Changed</h4>
+                <div class="chords-diff">
+                    <div class="chords-diff-panel">
+                        <div class="chords-diff-label">New</div>
+                        <div class="chords-preview">${submission.chords || "(empty)"}</div>
+                    </div>
+                    <div class="chords-diff-panel">
+                        <div class="chords-diff-label">Old</div>
+                        <div class="chords-preview chords-old">${original.chords || "(empty)"}</div>
+                    </div>
+                </div>
+            ` : nothing}
+
+            ${linksChanged ? html`
+                <h4 class="diff-section-title">Links Changed</h4>
+                <div class="links-diff">
+                    <div>
+                        <span class="detail-label">New</span>
+                        ${(submission.links ?? []).map(link => html`<a href="${link}" target="_blank" style="display:block; font-size: 0.9rem;">${link}</a>`)}
+                    </div>
+                    <div>
+                        <span class="detail-label">Old</span>
+                        ${(original.links ?? []).map(link => html`<a href="${link}" target="_blank" style="display:block; font-size: 0.9rem;">${link}</a>`)}
+                    </div>
+                </div>
+            ` : nothing}
+
+            ${changedFields.length === 0 && !chordsChanged && !linksChanged ? html`
+                <p class="no-changes">No field changes detected (only new attachments).</p>
+            ` : nothing}
+
+            ${unchangedFields.length > 0 ? html`
+                <details class="unchanged-details">
+                    <summary>Unchanged fields (${unchangedFields.length})</summary>
+                    <div class="submission-details">
+                        ${unchangedFields.map(f => this.renderDetailIfPresent(f.label, f.newVal))}
+                    </div>
+                </details>
+            ` : nothing}
+        `;
+    }
+
+    private renderDetailIfPresent(label: string, value: string | null | undefined): TemplateResult | typeof nothing {
+        if (!value) return nothing;
+        return html`
+            <div class="detail-item">
+                <span class="detail-label">${label}</span>
+                <span class="detail-value">${value}</span>
+            </div>
+        `;
+    }
+
     private async approve(submission: ChordSubmission): Promise<void> {
         if (!submission.id) return;
         await this.processSubmission(submission.id, () => adminService.approveSubmission(submission.id));
@@ -225,7 +303,7 @@ export class AdminSubmissions extends LitElement {
         this.error = null;
         try {
             await action();
-            this.submissions = this.submissions.filter(s => s.id !== submissionId);
+            this.pendingSubmissions = this.pendingSubmissions.filter(p => p.submission.id !== submissionId);
         } catch {
             this.error = `Failed to process submission ${submissionId}.`;
         } finally {

--- a/src/ClientApp/src/script/pages/chord-details.ts
+++ b/src/ClientApp/src/script/pages/chord-details.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { ChordSheet } from "../models/interfaces";
 import { ChordService } from "../services/chord-service";
@@ -322,7 +322,7 @@ export class ChordDetails extends LitElement {
         const transposeUpTooltip = chord.chords ? "Transpose the chords up a half-step" : "Transposing is disabled for this chord chart because it's in an unsupported format.";
         const transposeDownTooltip = chord.chords ? "Transpose the chords down a half-step" : "Transposing is disabled for this chord chart because it's in an unsupported format.";
         const btnSize = matchMedia("(max-width: 575px)").matches ? "small" : "medium";
-        const fontSizeClass = chord.chords ? "" : "d-none";
+        const hasChords = !!chord.chords;
         const starTitle = this.isCurrentChordStarred() ? "You already have starred this chord chart. Tap to unstar." : "Star this chord chart";
         const hasAudio = this.hasAudioPlayer(chord);
         const playPauseTooltip = this.isAudioPlaying
@@ -395,7 +395,8 @@ export class ChordDetails extends LitElement {
                             </sl-tooltip>
                         </sl-button-group>
                         
-                        <sl-button-group class="${fontSizeClass}" label="Font Size">
+                        ${hasChords ? html`
+                        <sl-button-group label="Font Size">
                             <sl-tooltip content="Increase font size" hoist>
                                 <sl-button size="${btnSize}" @click="${() => this.changeFontSize(2)}">
                                     <strong>A</strong> <sl-icon name="caret-up-fill"></sl-icon>
@@ -412,6 +413,7 @@ export class ChordDetails extends LitElement {
                                 </sl-button>
                             </sl-tooltip>
                         </sl-button-group>
+                        ` : nothing}
 
                     </div>
                     

--- a/src/ClientApp/src/script/services/account-service.ts
+++ b/src/ClientApp/src/script/services/account-service.ts
@@ -3,8 +3,9 @@ import { BehaviorSubject } from "rxjs";
 import { ApiServiceBase } from "./api-service-base";
 
 class AccountService extends ApiServiceBase {
-    currentUser: UserViewModel | null = null;
-    signedInState = new BehaviorSubject<boolean>(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    currentUser: UserViewModel | null = (window as any)["messianicChords"]?.user || null;
+    signedInState = new BehaviorSubject<boolean>(!!this.currentUser);
 
     async getUser(): Promise<UserViewModel | null> {
         if (this.currentUser) {

--- a/src/ClientApp/src/script/services/admin-service.ts
+++ b/src/ClientApp/src/script/services/admin-service.ts
@@ -1,9 +1,9 @@
-import { ChordSubmission } from "../models/chord-submission";
+import { PendingChordSubmission } from "../models/chord-submission";
 import { ApiServiceBase } from "./api-service-base";
 
 class AdminService extends ApiServiceBase {
-    getPendingSubmissions(): Promise<ChordSubmission[]> {
-        return this.getJson<ChordSubmission[]>("/api/chordsubmissions/pending");
+    getPendingSubmissions(): Promise<PendingChordSubmission[]> {
+        return this.getJson<PendingChordSubmission[]>("/api/chordsubmissions/pending");
     }
 
     approveSubmission(submissionId: string): Promise<{ message: string }> {

--- a/src/ClientApp/src/script/services/admin-service.ts
+++ b/src/ClientApp/src/script/services/admin-service.ts
@@ -1,0 +1,18 @@
+import { ChordSubmission } from "../models/chord-submission";
+import { ApiServiceBase } from "./api-service-base";
+
+class AdminService extends ApiServiceBase {
+    getPendingSubmissions(): Promise<ChordSubmission[]> {
+        return this.getJson<ChordSubmission[]>("/api/chordsubmissions/pending");
+    }
+
+    approveSubmission(submissionId: string): Promise<{ message: string }> {
+        return this.post<{ message: string }>("/api/chordsubmissions/approve", { submissionId, approved: true });
+    }
+
+    rejectSubmission(submissionId: string): Promise<{ message: string }> {
+        return this.post<{ message: string }>("/api/chordsubmissions/reject", { submissionId, approved: false });
+    }
+}
+
+export const adminService = new AdminService();

--- a/src/ClientApp/src/services/app-router.ts
+++ b/src/ClientApp/src/services/app-router.ts
@@ -131,6 +131,12 @@ export const appRouter = new Router({
             title: "About - " + appTitle,
             plugins: [lazy(() => import("../script/pages/about"))],
             render: () => html`<about-page></about-page>`
+        },
+        {
+            path: "/admin/submissions",
+            title: "Admin - Pending Submissions - " + appTitle,
+            plugins: [lazy(() => import("../script/pages/admin-submissions"))],
+            render: () => html`<admin-submissions></admin-submissions>`
         }
     ]
 });

--- a/src/Controllers/ChordSubmissionsController.cs
+++ b/src/Controllers/ChordSubmissionsController.cs
@@ -81,13 +81,33 @@ namespace MessianicChords.Controllers
         }
 
         /// <summary>
-        /// Gets all pending chord submissions. Admin only.
+        /// Gets all pending chord submissions with their original chord sheets (for edits). Admin only.
         /// </summary>
         [HttpGet("~/api/chordsubmissions/pending")]
         [Authorize(Roles = AppUser.AdminRole)]
-        public async Task<List<ChordSubmission>> GetPending()
+        public async Task<List<PendingChordSubmission>> GetPending()
         {
-            return await chordSubmissionService.GetAll(0, 100);
+            var submissions = await chordSubmissionService.GetAll(0, 100);
+
+            // Load the original chord sheets for edit submissions.
+            var editedIds = submissions
+                .Where(s => !string.IsNullOrWhiteSpace(s.EditedChordSheetId))
+                .Select(s => s.EditedChordSheetId!)
+                .Distinct()
+                .ToList();
+            var originals = editedIds.Count > 0
+                ? await dbSession.LoadAsync<ChordSheet>(editedIds)
+                : new Dictionary<string, ChordSheet>();
+
+            return submissions.Select(s =>
+            {
+                ChordSheet? original = null;
+                if (!string.IsNullOrWhiteSpace(s.EditedChordSheetId))
+                {
+                    originals.TryGetValue(s.EditedChordSheetId!, out original);
+                }
+                return new PendingChordSubmission(s, original);
+            }).ToList();
         }
 
         /// <summary>

--- a/src/Controllers/ChordSubmissionsController.cs
+++ b/src/Controllers/ChordSubmissionsController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Raven.Client.Documents.Session;
 using MessianicChords.Services;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Authorization;
 using System.Xml;
 using System.ServiceModel.Syndication;
 
@@ -77,6 +78,40 @@ namespace MessianicChords.Controllers
             writer.Flush();
 
             return Content(sw.ToString(), "application/xml");
+        }
+
+        /// <summary>
+        /// Gets all pending chord submissions. Admin only.
+        /// </summary>
+        [HttpGet("~/api/chordsubmissions/pending")]
+        [Authorize(Roles = AppUser.AdminRole)]
+        public async Task<List<ChordSubmission>> GetPending()
+        {
+            return await chordSubmissionService.GetAll(0, 100);
+        }
+
+        /// <summary>
+        /// Approves a chord submission. Admin only, no token required.
+        /// </summary>
+        [HttpPost("~/api/chordsubmissions/approve")]
+        [Authorize(Roles = AppUser.AdminRole)]
+        public async Task<IActionResult> Approve([FromBody] ChordSubmissionApproval decision)
+        {
+            decision.Approved = true;
+            await chordSubmissionService.ApproveOrRejectByAdmin(decision);
+            return Ok(new { message = "Chord chart submission approved." });
+        }
+
+        /// <summary>
+        /// Rejects a chord submission. Admin only, no token required.
+        /// </summary>
+        [HttpPost("~/api/chordsubmissions/reject")]
+        [Authorize(Roles = AppUser.AdminRole)]
+        public async Task<IActionResult> Reject([FromBody] ChordSubmissionApproval decision)
+        {
+            decision.Approved = false;
+            await chordSubmissionService.ApproveOrRejectByAdmin(decision);
+            return Ok(new { message = "Chord chart submission rejected." });
         }
     }
 }

--- a/src/Controllers/ChordsController.cs
+++ b/src/Controllers/ChordsController.cs
@@ -445,10 +445,9 @@ namespace MessianicChords.Controllers
         [Authorize(Roles = AppUser.AdminRole)]
         public async Task<string> ApproveRejectSubmission(
             [FromQuery] ChordSubmissionApproval decision,
-            [FromQuery] string token,
             [FromServices]ChordSubmissionService submissionService)
         {
-            await submissionService.ApproveOrReject(decision, token);
+            await submissionService.ApproveOrRejectByAdmin(decision);
             var approvalOrRejection = decision.Approved ? "approved" : "rejected";
             return $"Chord chart submission {approvalOrRejection}.";
         }

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -8,20 +8,17 @@ using System.Xml;
 namespace MessianicChords.Controllers
 {
     [Route("")]
-    public class HomeController : Controller
+    public class HomeController : RavenController
     {
-        private readonly IAsyncDocumentSession dbSession;
         private readonly IWebHostEnvironment webHost;
-        private readonly ILogger<HomeController> logger;
 
         public HomeController(
             IAsyncDocumentSession dbSession, 
             IWebHostEnvironment webHost, 
             ILogger<HomeController> logger)
+            : base(dbSession, logger)
         {
-            this.dbSession = dbSession;
             this.webHost = webHost;
-            this.logger = logger;
         }
 
         /// <summary>
@@ -32,9 +29,10 @@ namespace MessianicChords.Controllers
         [Route("/")]
         [Route("{*url}")]
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-        public IActionResult Index()
+        public async Task<IActionResult> Index()
         {
             var model = new HomeViewModel();
+            model.UpdateWithUser(await this.GetUserAsync());
             return View("Index", model);
         }
 
@@ -47,13 +45,14 @@ namespace MessianicChords.Controllers
         public async Task<IActionResult> ChordDetails(string id)
         {
             var model = new HomeViewModel();
-            var chordSheet = await dbSession.LoadOptionalAsync<ChordSheet>("chordsheets/" + id);
+            var chordSheet = await DbSession.LoadOptionalAsync<ChordSheet>("chordsheets/" + id);
             if (chordSheet == null)
             {
                 return Redirect("/");
             }
 
             model.UpdateFromChordSheet(chordSheet);
+            model.UpdateWithUser(await this.GetUserAsync());
             return View("Index", model);
         }
 
@@ -66,7 +65,7 @@ namespace MessianicChords.Controllers
         public async Task<IActionResult> Artist(string artistName)
         {
             var model = new HomeViewModel();
-            var chordSheetByArtist = await dbSession.Query<ChordSheet>()
+            var chordSheetByArtist = await DbSession.Query<ChordSheet>()
                 .Where(c => c.Artist == artistName)
                 .FirstOrDefaultAsync();
             if (chordSheetByArtist == null)
@@ -75,6 +74,7 @@ namespace MessianicChords.Controllers
             }
 
             model.UpdateFromArtist(chordSheetByArtist.Artist);
+            model.UpdateWithUser(await this.GetUserAsync());
             return View("Index", model);
         }
 
@@ -83,7 +83,7 @@ namespace MessianicChords.Controllers
         /// </summary>
         /// <returns></returns>
         [HttpGet("browse/{order}")]
-        public IActionResult Browse(string order)
+        public async Task<IActionResult> Browse(string order)
         {
             if (order != "newest" && order != "songs" && order != "artists" && order != "tags" && order != "random" && order != "offline")
             {
@@ -92,6 +92,7 @@ namespace MessianicChords.Controllers
 
             var model = new HomeViewModel();
             model.UpdateFromBrowse(order);
+            model.UpdateWithUser(await this.GetUserAsync());
             return View("Index", model);
         }
 
@@ -100,10 +101,11 @@ namespace MessianicChords.Controllers
         /// </summary>
         /// <returns></returns>
         [HttpGet("about")]
-        public IActionResult About()
+        public async Task<IActionResult> About()
         {
             var model = new HomeViewModel();
             model.UpdateFromAbout();
+            model.UpdateWithUser(await this.GetUserAsync());
             return View("Index", model);
         }
 
@@ -113,7 +115,7 @@ namespace MessianicChords.Controllers
             // Grab all the chord sheets with which we'll generate our site map.
             var chords = new List<ChordSheet>(3000);
             var artists = new HashSet<string>(1000);
-            await foreach (var doc in dbSession.Advanced.Stream<ChordSheet>())
+            await foreach (var doc in DbSession.Advanced.Stream<ChordSheet>())
             {
                 chords.Add(doc);
                 if (!string.IsNullOrEmpty(doc.Artist))

--- a/src/MessianicChords.csproj
+++ b/src/MessianicChords.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -6,6 +6,7 @@
     <SpaRoot>ClientApp\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dacf8c2e-64bb-4a47-9707-072a981e75cb</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <_WebToolingArtifacts Remove="Properties\PublishProfiles\MessianicChords.com.pubxml" />

--- a/src/Models/HomeViewModel.cs
+++ b/src/Models/HomeViewModel.cs
@@ -12,6 +12,7 @@ public class HomeViewModel
     public string SocialCardType { get; set; } = "website"; // For possible values, see https://ogp.me/
     public Uri SocialCardImage { get; set; } = new Uri("https://messianicchords.com/assets/images/512x512.png");
     public string TwitterHandle { get; set; } = "@MessianicChords";
+    public UserViewModel? User { get; set; }
 
     /// <summary>
     /// Updates the home view model to include title, description, etc. of a specific chord sheet.
@@ -66,5 +67,17 @@ public class HomeViewModel
         this.Description = $"About - Messianic Chords";
         this.Title = $"About - Messianic Chords";
         this.SocialCardUrl = new Uri($"https://messianicchords.com/about");
+    }
+
+    /// <summary>
+    /// Updates the view model with information about the current user.
+    /// </summary>
+    /// <param name="user">The current user.</param>
+    public void UpdateWithUser(AppUser? user)
+    {
+        if (user != null)
+        {
+            this.User = new UserViewModel(user);
+        }
     }
 }

--- a/src/Models/PendingChordSubmission.cs
+++ b/src/Models/PendingChordSubmission.cs
@@ -1,0 +1,23 @@
+﻿namespace MessianicChords.Models;
+
+/// <summary>
+/// A pending chord submission paired with its original chord sheet (if it's an edit).
+/// </summary>
+public class PendingChordSubmission
+{
+    public PendingChordSubmission(ChordSubmission submission, ChordSheet? original)
+    {
+        Submission = submission;
+        Original = original;
+    }
+
+    /// <summary>
+    /// The submitted chord chart changes.
+    /// </summary>
+    public ChordSubmission Submission { get; set; }
+
+    /// <summary>
+    /// The original chord sheet being edited. Null if this is a new chord chart submission.
+    /// </summary>
+    public ChordSheet? Original { get; set; }
+}

--- a/src/Models/UserViewModel.cs
+++ b/src/Models/UserViewModel.cs
@@ -106,6 +106,11 @@ namespace MessianicChords.Models
         public List<string> Roles { get; set; } = new List<string>();
 
         /// <summary>
+        /// Whether the user is an admin.
+        /// </summary>
+        public bool IsAdmin => Roles.Contains(AppUser.AdminRole);
+
+        /// <summary>
         /// The IDs of the chord charts the user has starred.
         /// </summary>
         public List<string> StarredChartIds { get; set; } = new List<string>();

--- a/src/Services/ChordSubmissionService.cs
+++ b/src/Services/ChordSubmissionService.cs
@@ -13,19 +13,16 @@ public class ChordSubmissionService
     private readonly ILogger<ChordSubmissionService> logger;
     private readonly IAsyncDocumentSession dbSession;
     private readonly BunnyCdnManagerService cdnService;
-    private readonly EmailService emailService;
     private readonly AlbumArtFetcher albumArtFetcher;
 
     public ChordSubmissionService(
         IAsyncDocumentSession dbSession,
         BunnyCdnManagerService cdnService,
-        EmailService emailService,
         AlbumArtFetcher albumArtFetcher,
         ILogger<ChordSubmissionService> logger)
     {
         this.dbSession = dbSession;
         this.cdnService = cdnService;
-        this.emailService = emailService;
         this.albumArtFetcher = albumArtFetcher;
         this.logger = logger;
     }
@@ -104,12 +101,7 @@ public class ChordSubmissionService
         await dbSession.StoreAsync(approvalToken);
         dbSession.SetRavenExpiration(approvalToken, DateTime.Now.AddDays(30));
 
-        var existingChordSheet = string.IsNullOrWhiteSpace(request.Id) ? null : await dbSession.LoadRequiredAsync<ChordSheet>(request.Id!);
-
         await dbSession.SaveChangesAsync();
-
-        // Send off an email to admins.
-        await emailService.SendChordSubmissionEmail(submission, existingChordSheet, approvalToken.Token);
 
         return (submission, token);
     }

--- a/src/Services/ChordSubmissionService.cs
+++ b/src/Services/ChordSubmissionService.cs
@@ -133,22 +133,54 @@ public class ChordSubmissionService
         }
     }
 
-    private async Task ApproveOrRejectCore(ChordSubmissionApproval decision, string token)
+    /// <summary>
+    /// Approves or rejects a chord submission by an admin without requiring an approval token.
+    /// </summary>
+    /// <param name="decision">The approval or rejection decision.</param>
+    public async Task ApproveOrRejectByAdmin(ChordSubmissionApproval decision)
     {
-        if (!decision.SubmissionId.StartsWith("ChordSubmissions/", StringComparison.OrdinalIgnoreCase))
+        try
         {
-            var badChordSubmissionIdError = new ArgumentException("Invalid chord submission ID");
-            badChordSubmissionIdError.Data.Add("chordSubmissionId", decision.SubmissionId);
-            throw badChordSubmissionIdError;
+            await ApproveOrRejectByAdminCore(decision);
+        }
+        catch (Exception error)
+        {
+            logger.LogError(error, "Admin unable to approve/deny chord submission {id} due to error. Submission details: {details}", decision.SubmissionId, decision);
+            throw;
+        }
+    }
+
+    private async Task ApproveOrRejectByAdminCore(ChordSubmissionApproval decision)
+    {
+        var submission = await LoadSubmissionOrThrow(decision.SubmissionId);
+
+        // Try to find and delete any associated approval token, but don't require it.
+        var approvalToken = string.IsNullOrEmpty(submission.ApproveRejectKey)
+            ? null
+            : await dbSession.LoadOptionalAsync<ApprovalToken>($"ApprovalTokens/{submission.ApproveRejectKey}");
+
+        var isNew = string.IsNullOrWhiteSpace(submission.EditedChordSheetId);
+        var chordSheet = isNew ? new ChordSheet() : await dbSession.LoadAsync<ChordSheet>(submission.EditedChordSheetId);
+        if (chordSheet == null)
+        {
+            var chordNotFoundError = new ArgumentException("Chord sheet was not found.");
+            chordNotFoundError.Data.Add("chordId", submission.EditedChordSheetId);
+            throw chordNotFoundError;
         }
 
-        var submission = await dbSession.LoadAsync<ChordSubmission>(decision.SubmissionId);
-        if (submission == null)
+        if (decision.Approved)
         {
-            var submissionNotFoundError = new ArgumentException("Chord submission was not found.");
-            submissionNotFoundError.Data.Add("chordSubmissionId", decision.SubmissionId);
-            throw submissionNotFoundError;
+            await this.Approve(decision, submission, chordSheet, approvalToken);
         }
+        else
+        {
+            await this.Reject(submission, approvalToken);
+        }
+    }
+
+    private async Task ApproveOrRejectCore(ChordSubmissionApproval decision, string token)
+    {
+        var submission = await LoadSubmissionOrThrow(decision.SubmissionId);
 
         var approvalToken = await dbSession.LoadOptionalAsync<ApprovalToken>($"ApprovalTokens/{token}");
         if (approvalToken == null)
@@ -178,12 +210,32 @@ public class ChordSubmissionService
         }
     }
 
+    private async Task<ChordSubmission> LoadSubmissionOrThrow(string submissionId)
+    {
+        if (!submissionId.StartsWith("ChordSubmissions/", StringComparison.OrdinalIgnoreCase))
+        {
+            var badChordSubmissionIdError = new ArgumentException("Invalid chord submission ID");
+            badChordSubmissionIdError.Data.Add("chordSubmissionId", submissionId);
+            throw badChordSubmissionIdError;
+        }
+
+        var submission = await dbSession.LoadAsync<ChordSubmission>(submissionId);
+        if (submission == null)
+        {
+            var submissionNotFoundError = new ArgumentException("Chord submission was not found.");
+            submissionNotFoundError.Data.Add("chordSubmissionId", submissionId);
+            throw submissionNotFoundError;
+        }
+
+        return submission;
+    }
+
     /// <summary>
     /// Approves the submission: applies the proposed changes in the submission to the target chord sheet. The submission will then be deleted.
     /// </summary>
     /// <param name="dbSession"></param>
     /// <returns></returns>
-    private async Task Approve(ChordSubmissionApproval approval, ChordSubmission submission, ChordSheet chordSheet, ApprovalToken token)
+    private async Task Approve(ChordSubmissionApproval approval, ChordSubmission submission, ChordSheet chordSheet, ApprovalToken? token)
     {
         // Fill the submission with data from the approval.
         // Then copy the submission to the real chord sheet.
@@ -219,7 +271,10 @@ public class ChordSubmissionService
 
         // Delete the submission, as its changes have been applied.
         dbSession.Delete(submission);
-        dbSession.Delete(token);
+        if (token != null)
+        {
+            dbSession.Delete(token);
+        }
         await dbSession.SaveChangesAsync(); // Save changes now before we delete the files from CDN
         await this.TryDeleteTempAttachments(submission);
     }
@@ -229,10 +284,13 @@ public class ChordSubmissionService
     /// </summary>
     /// <param name="dbSession"></param>
     /// <returns></returns>
-    private async Task Reject(ChordSubmission submission, ApprovalToken token)
+    private async Task Reject(ChordSubmission submission, ApprovalToken? token)
     {
         dbSession.Delete(submission);
-        dbSession.Delete(token);
+        if (token != null)
+        {
+            dbSession.Delete(token);
+        }
         await dbSession.SaveChangesAsync();
         await TryDeleteTempAttachments(submission);
     }

--- a/src/Services/EmailService.cs
+++ b/src/Services/EmailService.cs
@@ -21,22 +21,6 @@ public class EmailService
         this.logger = logger;
     }
 
-    /// <summary>
-    /// Sends an email notifying that a chord sheet has been edited or created and is awaiting approval.
-    /// </summary>
-    /// <param name="submission"></param>
-    /// <param name="original">The original chord sheet being edited. If this is a new chord sheet being submitted, this will be null.</param>
-    /// <param name="token">The approval token.</param>
-    /// <returns></returns>
-    public Task SendChordSubmissionEmail(ChordSubmission submission, ChordSheet? original, string token)
-    {
-        var htmlBody = original == null ?
-            this.GetNewChordsEmailHtml(submission, token) :
-            this.GetUpdatedChordsEmailHtml(submission, token);
-        var email = this.CreateEmail("MessianicChords: chord chart edit awaiting your approval", new EmailAddress(settings.UploadedAttachmentEmailRecipient), null, htmlBody);
-        return this.SendEmail(email);
-    }
-
     public Task SendWelcomeEmailAsync(string to)
     {
         var htmlBody = "<h1>Welcome to MessianicChords!</h1>" + 
@@ -73,24 +57,6 @@ public class EmailService
             $"<p><a href='https://messianicchords.com/confirmemail?email={destinationAddress}&token={token}'>Confirm email</a></p>";
         var email = this.CreateEmail("MessianicChords: Confirm your email", new EmailAddress(destinationAddress), null, body);
         return this.SendEmail(email);
-    }
-
-    private string GetNewChordsEmailHtml(ChordSubmission submission, string token)
-    {
-        return
-            "<h1>New chords uploaded to MessianicChords</h1>" +
-            "<p>" +
-            $"<a href='https://messianicchords.com/chordsubmissions/review?id={submission.Id?.ToLower()}&token={token}'>Review new chord chart</a>" +
-            "</p>";
-    }
-
-    private string GetUpdatedChordsEmailHtml(ChordSubmission submission, string token)
-    {
-        return "" +
-            "<h1>Chord chart edited on MessianicChords</h1>" +
-            "<p>" +
-            $"<a href='https://messianicchords.com/chordsubmissions/review?id={submission.Id?.ToLower()}&token={token}'>Review edited chord chart</a>" +
-            "</p>";
     }
 
     private SendGridMessage CreateEmail(string subject, EmailAddress to, string? plainText, string html)

--- a/src/Views/ChordSubmissions/ReviewEdited.cshtml
+++ b/src/Views/ChordSubmissions/ReviewEdited.cshtml
@@ -172,9 +172,9 @@
     <br />
     <br />
     <h2>
-        <a href='/chords/ApproveRejectSubmission?submissionId=@Uri.EscapeDataString(Model.Updated.Id ?? string.Empty)&approved=true&token=@Model.Token'>Approve</a>
+        <a href='/chords/ApproveRejectSubmission?submissionId=@Uri.EscapeDataString(Model.Updated.Id ?? string.Empty)&approved=true'>Approve</a>
         or
-        <a href='/chords/ApproveRejectSubmission?submissionId=@Uri.EscapeDataString(Model.Updated.Id ?? string.Empty)&approved=false&token=@Model.Token'>Reject</a>
+        <a href='/chords/ApproveRejectSubmission?submissionId=@Uri.EscapeDataString(Model.Updated.Id ?? string.Empty)&approved=false'>Reject</a>
     </h2>
 </body>
 </html>

--- a/src/Views/ChordSubmissions/ReviewNew.cshtml
+++ b/src/Views/ChordSubmissions/ReviewNew.cshtml
@@ -47,9 +47,9 @@
     <br />
     <br />
     <h2>
-        <a href='/chords/ApproveRejectSubmission?submissionId=@Uri.EscapeDataString(Model.NewChordChart.Id ?? string.Empty)&approved=true&token=@Model.Token'>Approve</a>
+        <a href='/chords/ApproveRejectSubmission?submissionId=@Uri.EscapeDataString(Model.NewChordChart.Id ?? string.Empty)&approved=true'>Approve</a>
         or 
-        <a href='/chords/ApproveRejectSubmission?submissionId=@Uri.EscapeDataString(Model.NewChordChart.Id ?? string.Empty)&approved=false&token=@Model.Token'>Reject</a>
+        <a href='/chords/ApproveRejectSubmission?submissionId=@Uri.EscapeDataString(Model.NewChordChart.Id ?? string.Empty)&approved=false'>Reject</a>
     </h2>
 </body>
 </html>

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -57,23 +57,7 @@
     <link rel="stylesheet" media="(prefers-color-scheme:light)" href="https://cdn.jsdelivr.net/npm/@@shoelace-style/shoelace@2.20.1/cdn/themes/light.css" />
     <link rel="stylesheet" media="(prefers-color-scheme:dark)" href="https://cdn.jsdelivr.net/npm/@@shoelace-style/shoelace@2.20.1/cdn/themes/dark.css" onload="document.documentElement.classList.add('sl-theme-dark');" />
 
-    @* In non-dev environments, use our real index files *@
-    <environment exclude="Development">
-        <link rel="stylesheet" asp-href-include="~/assets/js/index-*.css">
-        <script type="module" asp-src-include="~/assets/js/index-*.js"></script>
-
-        <script>
-            if ('serviceWorker' in navigator) { 
-                window.addEventListener("load", () => navigator.serviceWorker.register('/service-worker.js', { scope: '/' }));
-            }
-        </script>
-    </environment>
-
-    @* In development, we just point to our Vite dev server *@
-    <environment include="Development">
-        <script type="module" src="http://localhost:7777/src/app-index.ts"></script>
-    </environment>
-    <style>
+<style>
         :root {
             --title-font: 'Homemade Apple', cursive;
             --subtitle-font: 'Lora', serif;
@@ -100,6 +84,27 @@
             }
         }
     </style>
+
+    @* In non-dev environments, use our real index files *@
+    <environment exclude="Development">
+        <link rel="stylesheet" asp-href-include="~/assets/js/index-*.css">
+        <script type="module" asp-src-include="~/assets/js/index-*.js"></script>
+
+        <script>
+            if ('serviceWorker' in navigator) { 
+                window.addEventListener("load", () => navigator.serviceWorker.register('/service-worker.js', { scope: '/' }));
+            }
+        </script>
+    </environment>
+
+    @* In development, we just point to our Vite dev server *@
+    <environment include="Development">
+        <script type="module" src="http://localhost:7777/src/app-index.ts"></script>
+    </environment>
+
+    <script>
+        window.messianicChords = { user: @Html.Raw(Json.Serialize(Model.User)) };
+    </script>
 </head>
 <body>
     @RenderBody()


### PR DESCRIPTION
## Summary

Adds an admin-only UI at `/admin/submissions` where admins can view pending chord chart submissions and approve or reject them directly — no email/token workflow needed.

## Changes

### Admin Submissions UI
- New Lit web component (`admin-submissions`) showing all pending submissions with approve/reject buttons
- For **new chart** submissions: displays all submitted fields
- For **edited chart** submissions: shows a diff table highlighting which fields changed (new vs old values), with side-by-side chords comparison
- Badges clearly indicate "🆕 New Chart" vs "✏️ Edit"
- Added `/admin/submissions` route

### Backend API
- `GET /api/chordsubmissions/pending` — Returns pending submissions paired with their original chord sheets (for diff display)
- `POST /api/chordsubmissions/approve` — Approve a submission (admin-only, no token required)
- `POST /api/chordsubmissions/reject` — Reject a submission (admin-only, no token required)
- New `PendingChordSubmission` DTO and `ApproveOrRejectByAdmin` service method

### Token requirement removed
- Approval/rejection no longer requires a token — only admin authentication
- Updated existing `ApproveRejectSubmission` endpoint and Razor review views accordingly

### Email notifications removed
- Removed chord submission email notifications (`SendChordSubmissionEmail`) since admins now use the UI
- Removed `EmailService` dependency from `ChordSubmissionService`

### Bug fix: Font size buttons
- Fixed font size increase/decrease buttons on chord-details page always showing (even for non-plain-text charts) due to `d-none` class not being defined in shadow DOM styles
- Replaced with proper Lit conditional rendering